### PR TITLE
set content type on stream to avoid connection problems

### DIFF
--- a/OpenSextantToolbox/src/org/opensextant/matching/SolrTaggerRequest.java
+++ b/OpenSextantToolbox/src/org/opensextant/matching/SolrTaggerRequest.java
@@ -50,6 +50,8 @@ public class SolrTaggerRequest extends QueryRequest {
 
   @Override
   public Collection<ContentStream> getContentStreams() {
-    return Collections.singleton((ContentStream) new ContentStreamBase.StringStream(input));
+    ContentStreamBase.StringStream stream = new ContentStreamBase.StringStream(input);
+    stream.setContentType("application/octet-stream");
+    return Collections.singleton((ContentStream)stream);
   }
 }


### PR DESCRIPTION
set content type on stream to avoid connection problems
I was getting an error while posting queries to my Solr when the content type wasn't set.
