### PR TITLE
Changed Server to use PORT environment variable if set

### DIFF
--- a/src/org/opensextant/service/OpenSextantServer.java
+++ b/src/org/opensextant/service/OpenSextantServer.java
@@ -30,8 +30,15 @@ public class OpenSextantServer {
 		// Create a new Component.
 		Component component = new Component();
 
-		// Add a new HTTP server listening on port 8182.
-		Server srvr = new Server(Protocol.HTTP, 8182);
+		// get port from environment variable
+		String port_env = System.getenv("PORT");
+		int port = 8182;
+		if(port_env != null) {
+			port = Integer.parseInt(port_env);
+		}
+
+		// Add a new HTTP server listening on port.
+		Server srvr = new Server(Protocol.HTTP, port);
 		component.getServers().add(srvr);
 
 		// get some server properties or defaults


### PR DESCRIPTION
Server now checks to see if PORT environment variable has been set. Default port is 8182. This change was required to support Cloud Foundry deployment.