### PR TITLE
Add extended JSON result format

### DIFF
--- a/src/org/opensextant/service/processing/DocumentProcessorPool.java
+++ b/src/org/opensextant/service/processing/DocumentProcessorPool.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
+import org.opensextant.placedata.PlaceCandidate;
 import org.opensextant.service.OpenSextantExtractorResource;
 import org.opensextant.tagger.Document;
 import org.opensextant.tagger.Match;
@@ -242,6 +243,9 @@ public class DocumentProcessorPool {
 			if ("PLACE".equalsIgnoreCase(type)) {
 				tmpAnno.getFeatures().put("place", fm.get("bestPlace"));
 				tmpAnno.getFeatures().put("hierarchy", fm.get("hierarchy"));
+
+				PlaceCandidate pc = (PlaceCandidate) fm.get("placeCandidate");
+				tmpAnno.getFeatures().put("candidates", pc.getPlaces());
 			} else {
 				for (Entry<Object, Object> e : fm.entrySet()) {
 					String k = (String) e.getKey();


### PR DESCRIPTION
The goal of this PR is to make each annotation's list of alternative places available through the geotagger interface.

Lists of alternative places are added to a `Document`'s annotations in `DocumentProcessorPool`.`gateDocToDocument()` under the key "candidates". 

The lists are removed from the `Document`'s annotations after the "extjson" format case in `OpenSextantExtractorResource`.`convertResult()` is checked, allowing the remainder of `OpenSextantExtractorResource`.`convertResult()` to run as it currently does.  

The new "extjson" result format looks like this:

```json
{
  "title": "",
  "content": "Moscow",
  "annoList": [
    {
      "start": 0,
      "end": 6,
      "type": "PLACE",
      "matchText": "Moscow",
      "features": {
        "candidates": [
          {
            "placeName": "Moscow",
            "expandedPlaceName": null,
            "nameType": "name",
            "nameTypeSystem": null,
            "countryCode": "RU",
            "admin1": "RS48",
            "admin2": null,
            "featureClass": "Geo.featureType.PopulatedPlace",
            "featureCode": "PPLC",
            "sourceNameID": null,
            "sourceFeatureID": null,
            "placeID": "NGA-2960561",
            "source": "NGA",
            "nameBias": 0.05000000074505806,
            "idBias": 0.9549999833106995,
            "acountry": false,
            "anAdmin1": false,
            "abbreviation": false,
            "geocoord": {
              "latitude": 55.75222,
              "longitude": 37.61556
            },
            "latitude": 55.75222,
            "longitude": 37.61556,
            "nationalCapital": true
          },
          {
            "placeName": "Moscow",
            "expandedPlaceName": null,
            "nameType": "name",
            "nameTypeSystem": null,
            "countryCode": "RU",
            "admin1": "RS48",
            "admin2": null,
            "featureClass": "Geo.featureType.AdminRegion",
            "featureCode": "ADM1",
            "sourceNameID": null,
            "sourceFeatureID": null,
            "placeID": "NGA-2960570",
            "source": "NGA",
            "nameBias": 0,
            "idBias": 0.12999999523162842,
            "acountry": false,
            "anAdmin1": true,
            "abbreviation": false,
            "geocoord": {
              "latitude": 55.75,
              "longitude": 37.58333
            },
            "latitude": 55.75,
            "longitude": 37.58333,
            "nationalCapital": false
          }
        ],
        "hierarchy": "Geo.place.namedPlace",
        "place": {
          "placeName": "Moscow",
          "expandedPlaceName": null,
          "nameType": "name",
          "nameTypeSystem": null,
          "countryCode": "RU",
          "admin1": "RS48",
          "admin2": null,
          "featureClass": "Geo.featureType.PopulatedPlace",
          "featureCode": "PPLC",
          "sourceNameID": null,
          "sourceFeatureID": null,
          "placeID": "NGA-2960561",
          "source": "NGA",
          "nameBias": 0.05000000074505806,
          "idBias": 0.9549999833106995,
          "acountry": false,
          "anAdmin1": false,
          "abbreviation": false,
          "geocoord": {
            "latitude": 55.75222,
            "longitude": 37.61556
          },
          "latitude": 55.75222,
          "longitude": 37.61556,
          "nationalCapital": true
        }
      }
    }
  ]
}
```